### PR TITLE
Replace unittest with pytest in test suites

### DIFF
--- a/tests/test_lgx_rg.py
+++ b/tests/test_lgx_rg.py
@@ -1,6 +1,6 @@
-import pytest
 import os
 
+import pytest
 from numpy import ones, zeros, float64, array, append, isclose, genfromtxt
 from numpy.testing import assert_allclose
 
@@ -18,7 +18,7 @@ class TestLogisticRegression:
     @pytest.fixture(scope="module")
     def data3(self):
         return genfromtxt(TESTDATA3, delimiter=',')
-        
+
     @pytest.fixture(scope="module")
     def data4(self):
         return genfromtxt(TESTDATA4, delimiter=',')
@@ -31,6 +31,7 @@ class TestLogisticRegression:
 # COST FUNCTION
 
     def test_cost_func_data3_1(self, data3):
+
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, n = X.shape
@@ -478,4 +479,3 @@ class TestLogisticRegression:
         theta = array([[5.161], [0.206], [0.201]])
 
         assert not predict(X, theta)
-    

--- a/tests/test_lgx_rg.py
+++ b/tests/test_lgx_rg.py
@@ -15,15 +15,15 @@ TESTDATA4 = os.path.join(os.path.dirname(__file__), 'data4.csv')
 
 class TestLogisticRegression:
 
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def data3(self):
         return genfromtxt(TESTDATA3, delimiter=',')
         
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def data4(self):
         return genfromtxt(TESTDATA4, delimiter=',')
 
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def err(self):
         return 1e-4
 

--- a/tests/test_lgx_rg.py
+++ b/tests/test_lgx_rg.py
@@ -16,22 +16,21 @@ TESTDATA4 = os.path.join(os.path.dirname(__file__), 'data4.csv')
 class TestLogisticRegression:
 
     @pytest.fixture
-    def data3():
+    def data3(self):
         return genfromtxt(TESTDATA3, delimiter=',')
         
     @pytest.fixture
-    def data4():
+    def data4(self):
         return genfromtxt(TESTDATA4, delimiter=',')
 
     @pytest.fixture
-    def err():
+    def err(self):
         return 1e-4
 
 
 # COST FUNCTION
 
-    def test_cost_func_data3_1(data3):
-
+    def test_cost_func_data3_1(self, data3):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, n = X.shape
@@ -42,7 +41,7 @@ class TestLogisticRegression:
         assert isclose(0.693, cost_func(X, y, theta),
                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data3_2(data3):
+    def test_cost_func_data3_2(self, data3):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, _ = X.shape
@@ -53,7 +52,7 @@ class TestLogisticRegression:
         assert isclose(4.227, cost_func(X, y, theta),
                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data3_3(data3):
+    def test_cost_func_data3_3(self, data3):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, n = X.shape
@@ -64,7 +63,7 @@ class TestLogisticRegression:
         assert isclose(0.218, cost_func(X, y, theta),
                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data4_1(data4):
+    def test_cost_func_data4_1(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -75,7 +74,7 @@ class TestLogisticRegression:
         assert isclose(0.693, cost_func(X, y, theta),
                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data4_2(data4):
+    def test_cost_func_data4_2(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -88,7 +87,7 @@ class TestLogisticRegression:
                         cost_func(X, y, theta),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data4_3(data4):
+    def test_cost_func_data4_3(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -102,7 +101,7 @@ class TestLogisticRegression:
 
 # REGULARIZED COST FUNCTION
 
-    def test_reg_cost_func_data4_1(data4):
+    def test_reg_cost_func_data4_1(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -115,7 +114,7 @@ class TestLogisticRegression:
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_cost_func_data4_2(data4):
+    def test_reg_cost_func_data4_2(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -128,7 +127,7 @@ class TestLogisticRegression:
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_cost_func_data4_3(data4):
+    def test_reg_cost_func_data4_3(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -143,7 +142,7 @@ class TestLogisticRegression:
 
 # GRADIENT
 
-    def test_grad_data3_1(data3):
+    def test_grad_data3_1(self, data3):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, n = X.shape
@@ -155,7 +154,7 @@ class TestLogisticRegression:
                         grad(X, y, theta), rtol=0, atol=5e-05,
                         equal_nan=False)
 
-    def test_grad_data3_2(data3):
+    def test_grad_data3_2(self, data3):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, _ = X.shape
@@ -167,7 +166,7 @@ class TestLogisticRegression:
                         grad(X, y, theta), rtol=0, atol=0.001,
                         equal_nan=False)
 
-    def test_grad_data3_3(data3):
+    def test_grad_data3_3(self, data3):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, n = X.shape
@@ -179,7 +178,7 @@ class TestLogisticRegression:
                         grad(X, y, theta), rtol=0, atol=0.001,
                         equal_nan=False)
 
-    def test_grad_data3_4(data3):
+    def test_grad_data3_4(self, data3, err):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, n = X.shape
@@ -191,10 +190,10 @@ class TestLogisticRegression:
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data3_5(data3):
+    def test_grad_data3_5(self, data3, err):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, _ = X.shape
@@ -206,10 +205,10 @@ class TestLogisticRegression:
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data3_6(data3):
+    def test_grad_data3_6(self, data3, err):
         y = data3[:, -1:]
         X = data3[:, :-1]
         m, n = X.shape
@@ -221,10 +220,10 @@ class TestLogisticRegression:
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_1(data4):
+    def test_grad_data4_1(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -237,7 +236,7 @@ class TestLogisticRegression:
                         grad(X, y, theta),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_2(data4):
+    def test_grad_data4_2(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, _ = X.shape
@@ -252,7 +251,7 @@ class TestLogisticRegression:
                         grad(X, y, theta),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_3(data4):
+    def test_grad_data4_3(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -266,7 +265,7 @@ class TestLogisticRegression:
                         grad(X, y, theta),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_4(data4):
+    def test_grad_data4_4(self, data4, err):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -278,10 +277,10 @@ class TestLogisticRegression:
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_5(data4):
+    def test_grad_data4_5(self, data4, err):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, _ = X.shape
@@ -294,10 +293,10 @@ class TestLogisticRegression:
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_6(data4):
+    def test_grad_data4_6(self, data4, err):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -309,12 +308,12 @@ class TestLogisticRegression:
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
 # REGULARIZED GRADIENT
 
-    def test_reg_grad_data4_1(data4):
+    def test_reg_grad_data4_1(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -329,7 +328,7 @@ class TestLogisticRegression:
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_2(data4):
+    def test_reg_grad_data4_2(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -344,7 +343,7 @@ class TestLogisticRegression:
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_3(data4):
+    def test_reg_grad_data4_3(self, data4):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -361,7 +360,7 @@ class TestLogisticRegression:
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_4(data4):
+    def test_reg_grad_data4_4(self, data4, err):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -374,10 +373,10 @@ class TestLogisticRegression:
             return reg_cost_func(X, y, theta, _lambda)
 
         assert_allclose(reg_grad(X, y, theta, _lambda),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_5(data4):
+    def test_reg_grad_data4_5(self, data4, err):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -390,10 +389,10 @@ class TestLogisticRegression:
             return reg_cost_func(X, y, theta, _lambda)
 
         assert_allclose(reg_grad(X, y, theta, _lambda),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_6(data4):
+    def test_reg_grad_data4_6(self, data4, err):
         y = data4[:, -1:]
         X = data4[:, :-1]
         m, n = X.shape
@@ -406,7 +405,7 @@ class TestLogisticRegression:
             return reg_cost_func(X, y, theta, _lambda)
 
         assert_allclose(reg_grad(X, y, theta, _lambda),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001, equal_nan=False)
 
 # HYPOTHESIS
@@ -479,7 +478,4 @@ class TestLogisticRegression:
         theta = array([[5.161], [0.206], [0.201]])
 
         assert not predict(X, theta)
-
-
-if __name__ == '__main__':
-    unittest.main()
+    

--- a/tests/test_lgx_rg.py
+++ b/tests/test_lgx_rg.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 import os
 
 from numpy import ones, zeros, float64, array, append, isclose, genfromtxt
@@ -13,21 +13,27 @@ TESTDATA3 = os.path.join(os.path.dirname(__file__), 'data3.csv')
 TESTDATA4 = os.path.join(os.path.dirname(__file__), 'data4.csv')
 
 
-class TestLogisticRegression(unittest.TestCase):
+class TestLogisticRegression:
 
-    @classmethod
-    def setUpClass(cls):
-        cls.data3 = genfromtxt(TESTDATA3, delimiter=',')
-        cls.data4 = genfromtxt(TESTDATA4, delimiter=',')
-        cls.err = 1e-4
+    @pytest.fixture
+    def data3():
+        return genfromtxt(TESTDATA3, delimiter=',')
+        
+    @pytest.fixture
+    def data4():
+        return genfromtxt(TESTDATA4, delimiter=',')
+
+    @pytest.fixture
+    def err():
+        return 1e-4
 
 
 # COST FUNCTION
 
-    def test_cost_func_data3_1(self):
+    def test_cost_func_data3_1(data3):
 
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -36,9 +42,9 @@ class TestLogisticRegression(unittest.TestCase):
         assert isclose(0.693, cost_func(X, y, theta),
                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data3_2(self):
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+    def test_cost_func_data3_2(data3):
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, _ = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -47,9 +53,9 @@ class TestLogisticRegression(unittest.TestCase):
         assert isclose(4.227, cost_func(X, y, theta),
                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data3_3(self):
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+    def test_cost_func_data3_3(data3):
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -58,9 +64,9 @@ class TestLogisticRegression(unittest.TestCase):
         assert isclose(0.218, cost_func(X, y, theta),
                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data4_1(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_cost_func_data4_1(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -69,9 +75,9 @@ class TestLogisticRegression(unittest.TestCase):
         assert isclose(0.693, cost_func(X, y, theta),
                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data4_2(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_cost_func_data4_2(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -82,9 +88,9 @@ class TestLogisticRegression(unittest.TestCase):
                         cost_func(X, y, theta),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_func_data4_3(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_cost_func_data4_3(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -96,9 +102,9 @@ class TestLogisticRegression(unittest.TestCase):
 
 # REGULARIZED COST FUNCTION
 
-    def test_reg_cost_func_data4_1(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_cost_func_data4_1(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -109,9 +115,9 @@ class TestLogisticRegression(unittest.TestCase):
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_cost_func_data4_2(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_cost_func_data4_2(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -122,9 +128,9 @@ class TestLogisticRegression(unittest.TestCase):
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_cost_func_data4_3(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_cost_func_data4_3(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -137,9 +143,9 @@ class TestLogisticRegression(unittest.TestCase):
 
 # GRADIENT
 
-    def test_grad_data3_1(self):
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+    def test_grad_data3_1(data3):
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -149,9 +155,9 @@ class TestLogisticRegression(unittest.TestCase):
                         grad(X, y, theta), rtol=0, atol=5e-05,
                         equal_nan=False)
 
-    def test_grad_data3_2(self):
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+    def test_grad_data3_2(data3):
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, _ = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -161,9 +167,9 @@ class TestLogisticRegression(unittest.TestCase):
                         grad(X, y, theta), rtol=0, atol=0.001,
                         equal_nan=False)
 
-    def test_grad_data3_3(self):
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+    def test_grad_data3_3(data3):
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -173,10 +179,9 @@ class TestLogisticRegression(unittest.TestCase):
                         grad(X, y, theta), rtol=0, atol=0.001,
                         equal_nan=False)
 
-    def test_grad_data3_4(self):
-
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+    def test_grad_data3_4(data3):
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -189,10 +194,9 @@ class TestLogisticRegression(unittest.TestCase):
                         numerical_grad(J, theta, self.err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data3_5(self):
-
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+    def test_grad_data3_5(data3):
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, _ = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -205,10 +209,9 @@ class TestLogisticRegression(unittest.TestCase):
                         numerical_grad(J, theta, self.err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data3_6(self):
-
-        y = self.data3[:, -1:]
-        X = self.data3[:, :-1]
+    def test_grad_data3_6(data3):
+        y = data3[:, -1:]
+        X = data3[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -221,9 +224,9 @@ class TestLogisticRegression(unittest.TestCase):
                         numerical_grad(J, theta, self.err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_1(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_grad_data4_1(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -234,9 +237,9 @@ class TestLogisticRegression(unittest.TestCase):
                         grad(X, y, theta),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_2(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_grad_data4_2(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, _ = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -249,9 +252,9 @@ class TestLogisticRegression(unittest.TestCase):
                         grad(X, y, theta),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_3(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_grad_data4_3(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -263,9 +266,9 @@ class TestLogisticRegression(unittest.TestCase):
                         grad(X, y, theta),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_4(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_grad_data4_4(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -278,9 +281,9 @@ class TestLogisticRegression(unittest.TestCase):
                         numerical_grad(J, theta, self.err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_5(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_grad_data4_5(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, _ = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -294,9 +297,9 @@ class TestLogisticRegression(unittest.TestCase):
                         numerical_grad(J, theta, self.err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad_data4_6(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_grad_data4_6(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -311,9 +314,9 @@ class TestLogisticRegression(unittest.TestCase):
 
 # REGULARIZED GRADIENT
 
-    def test_reg_grad_data4_1(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_grad_data4_1(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -326,9 +329,9 @@ class TestLogisticRegression(unittest.TestCase):
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_2(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_grad_data4_2(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -341,9 +344,9 @@ class TestLogisticRegression(unittest.TestCase):
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_3(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_grad_data4_3(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -358,9 +361,9 @@ class TestLogisticRegression(unittest.TestCase):
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_4(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_grad_data4_4(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -374,9 +377,9 @@ class TestLogisticRegression(unittest.TestCase):
                         numerical_grad(J, theta, self.err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_5(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_grad_data4_5(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -390,9 +393,9 @@ class TestLogisticRegression(unittest.TestCase):
                         numerical_grad(J, theta, self.err),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_reg_grad_data4_6(self):
-        y = self.data4[:, -1:]
-        X = self.data4[:, :-1]
+    def test_reg_grad_data4_6(data4):
+        y = data4[:, -1:]
+        X = data4[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)

--- a/tests/test_lin_rg.py
+++ b/tests/test_lin_rg.py
@@ -1,7 +1,6 @@
-import pytest
 import os
 
-
+import pytest
 from numpy.testing import assert_allclose
 from numpy import ones, zeros, float64, array, append, genfromtxt
 
@@ -19,7 +18,7 @@ class TestLinearRegression:
     @pytest.fixture(scope="module")
     def data1(self):
         return genfromtxt(TESTDATA1, delimiter=',')
-        
+
     @pytest.fixture(scope="module")
     def data2(self):
         return genfromtxt(TESTDATA2, delimiter=',')
@@ -32,6 +31,7 @@ class TestLinearRegression:
 # NORMAL EQUATION
 
     def test_normal_eqn_data1(self, data1):
+
         y = data1[:, -1:]
         X = data1[:, :-1]
         m, n = X.shape

--- a/tests/test_lin_rg.py
+++ b/tests/test_lin_rg.py
@@ -16,15 +16,15 @@ TESTDATA2 = os.path.join(os.path.dirname(__file__), 'data2.csv')
 
 class TestLinearRegression:
 
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def data1(self):
         return genfromtxt(TESTDATA1, delimiter=',')
         
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def data2(self):
         return genfromtxt(TESTDATA2, delimiter=',')
 
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def err(self):
         return 1e-4
 

--- a/tests/test_lin_rg.py
+++ b/tests/test_lin_rg.py
@@ -14,7 +14,7 @@ TESTDATA1 = os.path.join(os.path.dirname(__file__), 'data1.csv')
 TESTDATA2 = os.path.join(os.path.dirname(__file__), 'data2.csv')
 
 
-class TestLinearRegression():
+class TestLinearRegression:
 
     @pytest.fixture
     def data1(self):

--- a/tests/test_lin_rg.py
+++ b/tests/test_lin_rg.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 import os
 
 
@@ -14,19 +14,26 @@ TESTDATA1 = os.path.join(os.path.dirname(__file__), 'data1.csv')
 TESTDATA2 = os.path.join(os.path.dirname(__file__), 'data2.csv')
 
 
-class TestLinearRegression(unittest.TestCase):
+class TestLinearRegression():
 
-    @classmethod
-    def setUpClass(cls):
-        cls.data1 = genfromtxt(TESTDATA1, delimiter=',')
-        cls.data2 = genfromtxt(TESTDATA2, delimiter=',')
-        cls.err = 1e-4
+    @pytest.fixture
+    def data1(self):
+        return genfromtxt(TESTDATA1, delimiter=',')
+        
+    @pytest.fixture
+    def data2(self):
+        return genfromtxt(TESTDATA2, delimiter=',')
+
+    @pytest.fixture
+    def err(self):
+        return 1e-4
+
 
 # NORMAL EQUATION
 
-    def test_normal_eqn_data1(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_normal_eqn_data1(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=int)
         X = append(intercept, X, axis=1)
@@ -35,9 +42,9 @@ class TestLinearRegression(unittest.TestCase):
                         normal_eqn(X, y),
                         rtol=0, atol=0.001)
 
-    def test_normal_eqn_data2(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_normal_eqn_data2(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=int)
         X = append(intercept, X, axis=1)
@@ -48,9 +55,9 @@ class TestLinearRegression(unittest.TestCase):
 
 # COST FUNCTION
 
-    def test_cost_func_data1_1(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_cost_func_data1_1(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -60,9 +67,9 @@ class TestLinearRegression(unittest.TestCase):
                         cost_func(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_cost_func_data1_2(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_cost_func_data1_2(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -72,9 +79,9 @@ class TestLinearRegression(unittest.TestCase):
                         cost_func(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_cost_func_data1_3(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_cost_func_data1_3(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -84,9 +91,9 @@ class TestLinearRegression(unittest.TestCase):
                         cost_func(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_cost_func_data2_1(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_cost_func_data2_1(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -96,9 +103,9 @@ class TestLinearRegression(unittest.TestCase):
                         cost_func(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_cost_func_data2_2(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_cost_func_data2_2(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -108,9 +115,9 @@ class TestLinearRegression(unittest.TestCase):
                         cost_func(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_cost_func_data2_3(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_cost_func_data2_3(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -122,9 +129,9 @@ class TestLinearRegression(unittest.TestCase):
 
 # REGULARIZED COST FUNCTION
 
-    def test_reg_cost_func_data1_1(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_cost_func_data1_1(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -135,9 +142,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_cost_func_data1_2(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_cost_func_data1_2(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -148,9 +155,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_cost_func_data1_3(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_cost_func_data1_3(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -161,9 +168,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_cost_func_data2_1(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_reg_cost_func_data2_1(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -174,9 +181,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_cost_func_data2_2(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_reg_cost_func_data2_2(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -187,9 +194,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_cost_func(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_cost_func_data2_3(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_reg_cost_func_data2_3(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -202,9 +209,9 @@ class TestLinearRegression(unittest.TestCase):
 
 # GRADIENT
 
-    def test_grad_data1_1(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_grad_data1_1(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -214,9 +221,9 @@ class TestLinearRegression(unittest.TestCase):
                         grad(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_grad_data1_2(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_grad_data1_2(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -226,9 +233,9 @@ class TestLinearRegression(unittest.TestCase):
                         grad(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_grad_data1_3(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_grad_data1_3(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -238,9 +245,9 @@ class TestLinearRegression(unittest.TestCase):
                         grad(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_grad_data1_4(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_grad_data1_4(self, data1, err):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -250,12 +257,12 @@ class TestLinearRegression(unittest.TestCase):
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001)
 
-    def test_grad_data1_5(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_grad_data1_5(self, data1, err):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -265,12 +272,12 @@ class TestLinearRegression(unittest.TestCase):
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001)
 
-    def test_grad_data1_6(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_grad_data1_6(self, data1, err):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -280,12 +287,12 @@ class TestLinearRegression(unittest.TestCase):
             return cost_func(X, y, theta)
 
         assert_allclose(grad(X, y, theta),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001)
 
-    def test_grad_data2_1(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_grad_data2_1(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -295,9 +302,9 @@ class TestLinearRegression(unittest.TestCase):
                         grad(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_grad_data2_2(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_grad_data2_2(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -307,9 +314,9 @@ class TestLinearRegression(unittest.TestCase):
                         grad(X, y, theta),
                         rtol=0, atol=0.001)
 
-    def test_grad_data2_3(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_grad_data2_3(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -321,9 +328,9 @@ class TestLinearRegression(unittest.TestCase):
 
 # REGULARIZED GRADIENT
 
-    def test_reg_grad_data1_1(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_grad_data1_1(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -334,9 +341,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_grad_data1_2(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_grad_data1_2(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -347,9 +354,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_grad_data1_3(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_grad_data1_3(self, data1):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -360,9 +367,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_grad_data1_4(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_grad_data1_4(self, data1, err):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -373,12 +380,12 @@ class TestLinearRegression(unittest.TestCase):
             return reg_cost_func(X, y, theta, _lambda)
 
         assert_allclose(reg_grad(X, y, theta, _lambda),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001)
 
-    def test_reg_grad_data1_5(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_grad_data1_5(self, data1, err):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -389,12 +396,12 @@ class TestLinearRegression(unittest.TestCase):
             return reg_cost_func(X, y, theta, _lambda)
 
         assert_allclose(reg_grad(X, y, theta, _lambda),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001)
 
-    def test_reg_grad_data1_6(self):
-        y = self.data1[:, -1:]
-        X = self.data1[:, :-1]
+    def test_reg_grad_data1_6(self, data1, err):
+        y = data1[:, -1:]
+        X = data1[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -405,12 +412,12 @@ class TestLinearRegression(unittest.TestCase):
             return reg_cost_func(X, y, theta, _lambda)
 
         assert_allclose(reg_grad(X, y, theta, _lambda),
-                        numerical_grad(J, theta, self.err),
+                        numerical_grad(J, theta, err),
                         rtol=0, atol=0.001)
 
-    def test_reg_grad_data2_1(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_reg_grad_data2_1(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -421,9 +428,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_grad_data2_2(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_reg_grad_data2_2(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -434,9 +441,9 @@ class TestLinearRegression(unittest.TestCase):
                         reg_grad(X, y, theta, _lambda),
                         rtol=0, atol=0.001)
 
-    def test_reg_grad_data2_3(self):
-        y = self.data2[:, -1:]
-        X = self.data2[:, :-1]
+    def test_reg_grad_data2_3(self, data2):
+        y = data2[:, -1:]
+        X = data2[:, :-1]
         m, n = X.shape
         intercept = ones((m, 1), dtype=float64)
         X = append(intercept, X, axis=1)
@@ -540,7 +547,3 @@ class TestLinearRegression(unittest.TestCase):
         assert_allclose([[-0.2]],
                         h(X, theta),
                         rtol=0, atol=0.001)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -472,10 +472,10 @@ class TestNeuralNetwork():
         theta = init_nn_weights(input_layer_size, hidden_layer_size,
                                 num_labels, n_hidden_layers)
 
-        self.assertEqual(theta[0].shape, (5, 4))
-        self.assertEqual(theta[1].shape, (5, 6))
-        self.assertEqual(theta[2].shape, (3, 6))
-        self.assertEqual(len(theta), (n_hidden_layers + 1))
+        assert theta[0].shape == (5, 4)
+        assert theta[1].shape == (5, 6)
+        assert theta[2].shape == (3, 6)
+        assert len(theta) == n_hidden_layers + 1
 
     def test_init_nn_weights2(self):
         num_labels = 10
@@ -486,13 +486,13 @@ class TestNeuralNetwork():
         theta = init_nn_weights(input_layer_size, hidden_layer_size,
                                 num_labels, n_hidden_layers)
 
-        self.assertEqual(theta[0].shape, (25, 51))
-        self.assertEqual(theta[1].shape, (25, 26))
-        self.assertEqual(theta[2].shape, (25, 26))
-        self.assertEqual(theta[3].shape, (25, 26))
-        self.assertEqual(theta[4].shape, (25, 26))
-        self.assertEqual(theta[5].shape, (10, 26))
-        self.assertEqual(len(theta), (n_hidden_layers + 1))
+        assert theta[0].shape == (25, 51)
+        assert theta[1].shape == (25, 26)
+        assert theta[2].shape == (25, 26)
+        assert theta[3].shape == (25, 26)
+        assert theta[4].shape == (25, 26)
+        assert theta[5].shape == (10, 26)
+        assert len(theta) == n_hidden_layers + 1
 
     def test_unravel_params1(self):
         num_labels = 3
@@ -511,9 +511,9 @@ class TestNeuralNetwork():
         inflated = unravel_params(flat, input_layer_size, hidden_layer_size,
                                   num_labels, n_hidden_layers)
 
-        self.assertEqual(inflated[0].shape, theta[0].shape)
-        self.assertEqual(inflated[1].shape, theta[1].shape)
-        self.assertEqual(len(inflated), (n_hidden_layers + 1))
+        assert inflated[0].shape == theta[0].shape
+        assert inflated[1].shape == theta[1].shape
+        assert len(inflated) == n_hidden_layers + 1
 
     def test_unravel_params2(self):
         num_labels = 3
@@ -535,10 +535,10 @@ class TestNeuralNetwork():
         inflated = unravel_params(flat, input_layer_size, hidden_layer_size,
                                   num_labels, n_hidden_layers)
 
-        self.assertEqual(inflated[0].shape, theta[0].shape)
-        self.assertEqual(inflated[1].shape, theta[1].shape)
-        self.assertEqual(inflated[2].shape, theta[2].shape)
-        self.assertEqual(len(inflated), (n_hidden_layers + 1))
+        assert inflated[0].shape == theta[0].shape
+        assert inflated[1].shape == theta[1].shape
+        assert inflated[2].shape == theta[2].shape
+        assert len(inflated) == n_hidden_layers + 1
 
     def test_unravel_params3(self):
         num_labels = 10
@@ -569,10 +569,10 @@ class TestNeuralNetwork():
         inflated = unravel_params(flat, input_layer_size, hidden_layer_size,
                                   num_labels, n_hidden_layers)
 
-        self.assertEqual(inflated[0].shape, theta[0].shape)
-        self.assertEqual(inflated[1].shape, theta[1].shape)
-        self.assertEqual(inflated[2].shape, theta[2].shape)
-        self.assertEqual(inflated[3].shape, theta[3].shape)
-        self.assertEqual(inflated[4].shape, theta[4].shape)
-        self.assertEqual(inflated[5].shape, theta[5].shape)
-        self.assertEqual(len(inflated), (n_hidden_layers + 1))
+        assert inflated[0].shape == theta[0].shape
+        assert inflated[1].shape == theta[1].shape
+        assert inflated[2].shape == theta[2].shape
+        assert inflated[3].shape == theta[3].shape
+        assert inflated[4].shape == theta[4].shape
+        assert inflated[5].shape == theta[5].shape
+        assert len(inflated) == n_hidden_layers + 1

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -8,7 +8,7 @@ from ml_algorithms.nn import (feed_forward, init_nn_weights,
                               grad, unravel_params)
 
 
-class TestNeuralNetwork():
+class TestNeuralNetwork:
     
     @pytest.fixture
     def omicron(self):

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from numpy import array, append, empty, zeros, int64
 from numpy.testing import assert_allclose
@@ -8,35 +8,51 @@ from ml_algorithms.nn import (feed_forward, init_nn_weights,
                               grad, unravel_params)
 
 
-class TestNeuralNetwork(unittest.TestCase):
-    @classmethod
-    def setUp(cls):
-        cls.omicron = array([[0.35, 0.78, 0.13, 0.90],
-                             [0.27, 0.66, 0.62, 0.20],
-                             [0.64, 0.36, 0.76, 0.33],
-                             [0.00, 0.70, 0.78, 0.85],
-                             [0.55, 0.72, 0.24, 0.43]])
-        cls.omega = array([[0.86, 0.77, 0.63, 0.35, 0.99, 0.11],
-                           [0.84, 0.74, 0.11, 0.30, 0.49, 0.14],
-                           [0.04, 0.31, 0.17, 0.65, 0.28, 0.99]])
-        cls.kappa = array([[0.98, 0.6, 0.18, 0.47, 0.07, 1],
-                           [0.9, 0.38, 0.38, 0.36, 0.52, 0.85],
-                           [0.57, 0.23, 0.41, 0.45, 0.04, 0.24],
-                           [0.46, 0.94, 0.03, 0.06, 0.19, 0.63],
-                           [0.87, 0.4, 0.85, 0.07, 0.81, 0.76]])
-        cls.upsilon = array([[0.9, 0.95, 0.05, 0.05, 0.65, 0.11],
-                             [0.84, 0.57, 0.17, 0.62, 0.06, 0.36],
-                             [0.36, 0.6, 0.54, 0.49, 0.3, 0.03],
-                             [0.11, 0.49, 0.71, 0.43, 0.01, 0.92],
-                             [0.02, 0.01, 0.94, 0.35, 0.69, 0.88]])
-        cls.zeta = array([[0.91672, 0.85806, 0.81484],
-                          [0.89115, 0.83518, 0.78010],
-                          [0.93880, 0.88464, 0.84335]])
-        cls.iota = array([[0.017, 0.422, 0.739, -0.121, 0.479],
-                          [-0.346, 0.018, 0.37, -0.65, 0.148],
-                          [0.781, 0.484, 0.9405, 0.5385, 0.7915]])
-
-    def test_cost_function1(self):
+class TestNeuralNetwork():
+    
+    @pytest.fixture
+    def omicron(self):
+        return array([[0.35, 0.78, 0.13, 0.90],
+                      [0.27, 0.66, 0.62, 0.20],
+                      [0.64, 0.36, 0.76, 0.33],
+                      [0.00, 0.70, 0.78, 0.85],
+                      [0.55, 0.72, 0.24, 0.43]])
+    
+    @pytest.fixture
+    def omega(self):
+        return array([[0.86, 0.77, 0.63, 0.35, 0.99, 0.11],
+                      [0.84, 0.74, 0.11, 0.30, 0.49, 0.14],
+                      [0.04, 0.31, 0.17, 0.65, 0.28, 0.99]])
+    
+    @pytest.fixture
+    def kappa(self):
+        return array([[0.98, 0.6, 0.18, 0.47, 0.07, 1],
+                      [0.9, 0.38, 0.38, 0.36, 0.52, 0.85],
+                      [0.57, 0.23, 0.41, 0.45, 0.04, 0.24],
+                      [0.46, 0.94, 0.03, 0.06, 0.19, 0.63],
+                      [0.87, 0.4, 0.85, 0.07, 0.81, 0.76]])
+    
+    @pytest.fixture
+    def upsilon(self):
+        return array([[0.9, 0.95, 0.05, 0.05, 0.65, 0.11],
+                      [0.84, 0.57, 0.17, 0.62, 0.06, 0.36],
+                      [0.36, 0.6, 0.54, 0.49, 0.3, 0.03],
+                      [0.11, 0.49, 0.71, 0.43, 0.01, 0.92],
+                      [0.02, 0.01, 0.94, 0.35, 0.69, 0.88]])
+    
+    @pytest.fixture
+    def zeta(self):
+        return array([[0.91672, 0.85806, 0.81484],
+                      [0.89115, 0.83518, 0.78010],
+                      [0.93880, 0.88464, 0.84335]])
+    
+    @pytest.fixture
+    def iota(self):
+        return array([[0.017, 0.422, 0.739, -0.121, 0.479],
+                      [-0.346, 0.018, 0.37, -0.65, 0.148],
+                      [0.781, 0.484, 0.9405, 0.5385, 0.7915]])
+    
+    def test_cost_function1(self, omicron, omega):
         X = array([[0.10, 0.30, -0.50], [-0.20, 0, -0.60], [0, 0.20, 0.45]])
         y = array([[0], [2], [1]])
         n_hidden_layers = 1
@@ -44,15 +60,15 @@ class TestNeuralNetwork(unittest.TestCase):
         _lambda = 0
 
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.omega
+        theta[0] = omicron
+        theta[1] = omega
 
         assert_allclose(cost_function(X, y, theta, _lambda,
                                       num_labels, n_hidden_layers),
                         4.2549,
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_function2(self):
+    def test_cost_function2(self, omicron, omega):
         X = array([[0.10, 0.30, -0.50], [-0.20, 0, -0.60], [0, 0.20, 0.45]])
         y = array([[0], [2], [1]])
         n_hidden_layers = 1
@@ -60,15 +76,15 @@ class TestNeuralNetwork(unittest.TestCase):
         _lambda = 1
 
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.omega
+        theta[0] = omicron
+        theta[1] = omega
 
         assert_allclose(cost_function(X, y, theta, _lambda,
                                       num_labels, n_hidden_layers),
                         5.9738,
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_function3(self):
+    def test_cost_function3(self, omicron, omega):
         X = array([[0.10, 0.30, -0.50], [-0.20, 0, -0.60], [0, 0.20, 0.45]])
         y = array([[0], [2], [1]])
         n_hidden_layers = 1
@@ -76,15 +92,15 @@ class TestNeuralNetwork(unittest.TestCase):
         _lambda = 10
 
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.omega
+        theta[0] = omicron
+        theta[1] = omega
 
         assert_allclose(cost_function(X, y, theta, _lambda,
                                       num_labels, n_hidden_layers),
                         21.443,
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_function4(self):
+    def test_cost_function4(self, omicron, omega, kappa, upsilon):
         X = array([[0.10, 0.30, -0.50], [-0.20, 0, -0.60], [0, 0.20, 0.45]])
         y = array([[0], [2], [1]])
         n_hidden_layers = 3
@@ -92,17 +108,17 @@ class TestNeuralNetwork(unittest.TestCase):
         _lambda = 0
 
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.kappa
-        theta[2] = self.upsilon
-        theta[3] = self.omega
+        theta[0] = omicron
+        theta[1] = kappa
+        theta[2] = upsilon
+        theta[3] = omega
 
         assert_allclose(cost_function(X, y, theta, _lambda,
                                       num_labels, n_hidden_layers),
                         5.6617,
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_function5(self):
+    def test_cost_function5(self, omicron, omega, kappa, upsilon):
         X = array([[0.10, 0.30, -0.50], [-0.20, 0, -0.60], [0, 0.20, 0.45]])
         y = array([[0], [2], [1]])
         n_hidden_layers = 3
@@ -110,17 +126,17 @@ class TestNeuralNetwork(unittest.TestCase):
         _lambda = 1
 
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.kappa
-        theta[2] = self.upsilon
-        theta[3] = self.omega
+        theta[0] = omicron
+        theta[1] = kappa
+        theta[2] = upsilon
+        theta[3] = omega
 
         assert_allclose(cost_function(X, y, theta, _lambda,
                                       num_labels, n_hidden_layers),
                         9.7443,
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_cost_function6(self):
+    def test_cost_function6(self, omicron, omega, kappa, upsilon):
         X = array([[0.10, 0.30, -0.50], [-0.20, 0, -0.60], [0, 0.20, 0.45]])
         y = array([[0], [2], [1]])
         n_hidden_layers = 3
@@ -128,23 +144,23 @@ class TestNeuralNetwork(unittest.TestCase):
         _lambda = 10
 
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.kappa
-        theta[2] = self.upsilon
-        theta[3] = self.omega
+        theta[0] = omicron
+        theta[1] = kappa
+        theta[2] = upsilon
+        theta[3] = omega
 
         assert_allclose(cost_function(X, y, theta, _lambda,
                                       num_labels, n_hidden_layers),
                         46.488,
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_feed_forward1(self):
+    def test_feed_forward1(self, omicron, omega):
         n_hidden_layers = 1
         X = array([[1, 0.10, 0.30, -0.50]])
 
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.omega
+        theta[0] = omicron
+        theta[1] = omega
 
         z, a = feed_forward(X, theta)
 
@@ -165,13 +181,13 @@ class TestNeuralNetwork(unittest.TestCase):
                         array([[0.017, 0.422, 0.739, -0.121, 0.479]]),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_feed_forward2(self):
+    def test_feed_forward2(self, omicron, omega):
         n_hidden_layers = 1
         X = array([[1, -0.2, 0, -0.6]])
 
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.omega
+        theta[0] = omicron
+        theta[1] = omega
 
         z, a = feed_forward(X, theta)
 
@@ -192,12 +208,12 @@ class TestNeuralNetwork(unittest.TestCase):
                         array([[-0.346, 0.018, 0.37, -0.65, 0.148]]),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_feed_forward3(self):
+    def test_feed_forward3(self, omicron, omega):
         n_hidden_layers = 1
         X = array([[1, 0, 0.2, 0.45]])
         theta = empty((n_hidden_layers + 1), dtype=object)
-        theta[0] = self.omicron
-        theta[1] = self.omega
+        theta[0] = omicron
+        theta[1] = omega
 
         z, a = feed_forward(X, theta, n_hidden_layers)
         assert_allclose(a[0],
@@ -220,15 +236,15 @@ class TestNeuralNetwork(unittest.TestCase):
                         array([[2.73048142, 2.03713759, 1.68336723]]),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_feed_forward4(self):
+    def test_feed_forward4(self, omicron, omega, kappa, upsilon):
         n_hidden_layers = 3
         X = array([[1, 0, 0.2, 0.45]])
         theta = empty((n_hidden_layers + 1), dtype=object)
 
-        theta[0] = self.omicron
-        theta[1] = self.kappa
-        theta[2] = self.upsilon
-        theta[3] = self.omega
+        theta[0] = omicron
+        theta[1] = kappa
+        theta[2] = upsilon
+        theta[3] = omega
 
         z, a = feed_forward(X, theta, n_hidden_layers)
 
@@ -264,7 +280,7 @@ class TestNeuralNetwork(unittest.TestCase):
                         array([[3.4772, 2.4749, 2.2417]]),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_grad(self):
+    def test_grad(self, omicron, omega):
         X = array([[0.10, 0.30, -0.50], [-0.20, 0, -0.60], [0, 0.20, 0.45]])
         y = array([[0], [2], [1]])
 
@@ -276,8 +292,8 @@ class TestNeuralNetwork(unittest.TestCase):
 
         theta = empty((n_hidden_layers + 1), dtype=object)
 
-        theta[0] = self.omicron
-        theta[1] = self.omega
+        theta[0] = omicron
+        theta[1] = omega
 
         nn_params = append(theta[0].flatten(), theta[1].flatten())
         for i in range(2, len(theta)):
@@ -313,7 +329,7 @@ class TestNeuralNetwork(unittest.TestCase):
                              0.34265, 0.27997, 0.32182]]),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_back_prop_1(self):
+    def test_back_prop_1(self, omega, zeta, iota):
         num_labels = 3
         y = array([[0]])
         n_hidden_layers = 1
@@ -323,9 +339,9 @@ class TestNeuralNetwork(unittest.TestCase):
         a = empty((n_hidden_layers + 2), dtype=object)
         z = empty((n_hidden_layers + 2), dtype=object)
 
-        theta[1] = self.omega
-        a[2] = self.zeta
-        z[1] = self.iota
+        theta[1] = omega
+        a[2] = zeta
+        z[1] = iota
 
         delta = back_propagation(y, theta, a, z, num_labels, n_hidden_layers)
 
@@ -344,7 +360,7 @@ class TestNeuralNetwork(unittest.TestCase):
                                [-0.061198, 0.884641, 0.843350]]),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_back_prop_2(self):
+    def test_back_prop_2(self, omega, zeta, iota):
         num_labels = 3
         y = array([[2]])
         n_hidden_layers = 1
@@ -354,9 +370,9 @@ class TestNeuralNetwork(unittest.TestCase):
         a = empty((n_hidden_layers + 2), dtype=object)
         z = empty((n_hidden_layers + 2), dtype=object)
 
-        theta[1] = self.omega
-        a[2] = self.zeta
-        z[1] = self.iota
+        theta[1] = omega
+        a[2] = zeta
+        z[1] = iota
 
         delta = back_propagation(y, theta, a, z, num_labels, n_hidden_layers)
 
@@ -375,7 +391,7 @@ class TestNeuralNetwork(unittest.TestCase):
                                [0.93880, 0.88464, -0.15665]]),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_back_prop_3(self):
+    def test_back_prop_3(self, omega, zeta, iota):
         num_labels = 3
         y = array([[1]])
         n_hidden_layers = 1
@@ -385,9 +401,9 @@ class TestNeuralNetwork(unittest.TestCase):
         a = empty((n_hidden_layers + 2), dtype=object)
         z = empty((n_hidden_layers + 2), dtype=object)
 
-        theta[1] = self.omega
-        a[2] = self.zeta
-        z[1] = self.iota
+        theta[1] = omega
+        a[2] = zeta
+        z[1] = iota
 
         delta = back_propagation(y, theta, a, z, num_labels, n_hidden_layers)
 
@@ -403,7 +419,7 @@ class TestNeuralNetwork(unittest.TestCase):
                                [0.93880, -0.11536, 0.84335]]),
                         rtol=0, atol=0.001, equal_nan=False)
 
-    def test_back_prop_4(self):
+    def test_back_prop_4(self, omicron, omega, kappa, upsilon):
         num_labels = 3
         y = array([[1]])
         n_hidden_layers = 3
@@ -413,10 +429,10 @@ class TestNeuralNetwork(unittest.TestCase):
         z = empty((n_hidden_layers + 2), dtype=object)
         a = empty((n_hidden_layers + 2), dtype=object)
 
-        theta[0] = self.omicron
-        theta[1] = self.kappa
-        theta[2] = self.upsilon
-        theta[3] = self.omega
+        theta[0] = omicron
+        theta[1] = kappa
+        theta[2] = upsilon
+        theta[3] = omega
 
         a[0] = array([[1, 0, 0.2, 0.45]])
         a[1] = array([[1, 0.6859, 0.61869, 0.7192, 0.63146, 0.68815]])

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -10,7 +10,7 @@ from ml_algorithms.nn import (feed_forward, init_nn_weights,
 
 class TestNeuralNetwork:
     
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def omicron(self):
         return array([[0.35, 0.78, 0.13, 0.90],
                       [0.27, 0.66, 0.62, 0.20],
@@ -18,13 +18,13 @@ class TestNeuralNetwork:
                       [0.00, 0.70, 0.78, 0.85],
                       [0.55, 0.72, 0.24, 0.43]])
     
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def omega(self):
         return array([[0.86, 0.77, 0.63, 0.35, 0.99, 0.11],
                       [0.84, 0.74, 0.11, 0.30, 0.49, 0.14],
                       [0.04, 0.31, 0.17, 0.65, 0.28, 0.99]])
     
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def kappa(self):
         return array([[0.98, 0.6, 0.18, 0.47, 0.07, 1],
                       [0.9, 0.38, 0.38, 0.36, 0.52, 0.85],
@@ -32,7 +32,7 @@ class TestNeuralNetwork:
                       [0.46, 0.94, 0.03, 0.06, 0.19, 0.63],
                       [0.87, 0.4, 0.85, 0.07, 0.81, 0.76]])
     
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def upsilon(self):
         return array([[0.9, 0.95, 0.05, 0.05, 0.65, 0.11],
                       [0.84, 0.57, 0.17, 0.62, 0.06, 0.36],
@@ -40,13 +40,13 @@ class TestNeuralNetwork:
                       [0.11, 0.49, 0.71, 0.43, 0.01, 0.92],
                       [0.02, 0.01, 0.94, 0.35, 0.69, 0.88]])
     
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def zeta(self):
         return array([[0.91672, 0.85806, 0.81484],
                       [0.89115, 0.83518, 0.78010],
                       [0.93880, 0.88464, 0.84335]])
     
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def iota(self):
         return array([[0.017, 0.422, 0.739, -0.121, 0.479],
                       [-0.346, 0.018, 0.37, -0.65, 0.148],

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1,5 +1,4 @@
 import pytest
-
 from numpy import array, append, empty, zeros, int64
 from numpy.testing import assert_allclose
 
@@ -9,7 +8,7 @@ from ml_algorithms.nn import (feed_forward, init_nn_weights,
 
 
 class TestNeuralNetwork:
-    
+
     @pytest.fixture(scope="module")
     def omicron(self):
         return array([[0.35, 0.78, 0.13, 0.90],
@@ -17,13 +16,13 @@ class TestNeuralNetwork:
                       [0.64, 0.36, 0.76, 0.33],
                       [0.00, 0.70, 0.78, 0.85],
                       [0.55, 0.72, 0.24, 0.43]])
-    
+
     @pytest.fixture(scope="module")
     def omega(self):
         return array([[0.86, 0.77, 0.63, 0.35, 0.99, 0.11],
                       [0.84, 0.74, 0.11, 0.30, 0.49, 0.14],
                       [0.04, 0.31, 0.17, 0.65, 0.28, 0.99]])
-    
+
     @pytest.fixture(scope="module")
     def kappa(self):
         return array([[0.98, 0.6, 0.18, 0.47, 0.07, 1],
@@ -31,7 +30,7 @@ class TestNeuralNetwork:
                       [0.57, 0.23, 0.41, 0.45, 0.04, 0.24],
                       [0.46, 0.94, 0.03, 0.06, 0.19, 0.63],
                       [0.87, 0.4, 0.85, 0.07, 0.81, 0.76]])
-    
+
     @pytest.fixture(scope="module")
     def upsilon(self):
         return array([[0.9, 0.95, 0.05, 0.05, 0.65, 0.11],
@@ -39,19 +38,19 @@ class TestNeuralNetwork:
                       [0.36, 0.6, 0.54, 0.49, 0.3, 0.03],
                       [0.11, 0.49, 0.71, 0.43, 0.01, 0.92],
                       [0.02, 0.01, 0.94, 0.35, 0.69, 0.88]])
-    
+
     @pytest.fixture(scope="module")
     def zeta(self):
         return array([[0.91672, 0.85806, 0.81484],
                       [0.89115, 0.83518, 0.78010],
                       [0.93880, 0.88464, 0.84335]])
-    
+
     @pytest.fixture(scope="module")
     def iota(self):
         return array([[0.017, 0.422, 0.739, -0.121, 0.479],
                       [-0.346, 0.018, 0.37, -0.65, 0.148],
                       [0.781, 0.484, 0.9405, 0.5385, 0.7915]])
-    
+
     def test_cost_function1(self, omicron, omega):
         X = array([[0.10, 0.30, -0.50], [-0.20, 0, -0.60], [0, 0.20, 0.45]])
         y = array([[0], [2], [1]])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ from ml_algorithms.utils import numerical_grad, g_grad
 
 class TestLogisticRegression:
 
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def err(self):
         return 0.0001
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 from math import radians
-import unittest
+import pytest
 
 from numpy import array, cos, sin, exp
 from numpy.testing import assert_allclose
@@ -7,34 +7,37 @@ from numpy.testing import assert_allclose
 from ml_algorithms.utils import numerical_grad, g_grad
 
 
-class TestLogisticRegression(unittest.TestCase):
+class TestLogisticRegression:
 
-    def test_numeric_grad_1(self):
+    @pytest.fixture
+    def err(self):
+        return 0.0001
 
+    @pytest.fixture
+    def atol(self):
+        return 0.001
+
+    def test_numeric_grad_1(self, err, atol):
         def J(x):
             return sum(3 * (x ** 2))
 
         theta = array([[0], [4], [10]])
-        err = 0.0001
 
         assert_allclose(array([[0], [24], [60]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=0.001, equal_nan=False)
+                        rtol=0, atol=atol, equal_nan=False)
 
-    def test_numeric_grad_2(self):
-
+    def test_numeric_grad_2(self, err, atol):
         def J(x):
             return sum(1 / x)
 
         theta = array([[5], [8], [20]])
-        err = 0.0001
 
         assert_allclose(array([[-0.04], [-0.015625], [-0.0025]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=0.001, equal_nan=False)
+                        rtol=0, atol=atol, equal_nan=False)
 
-    def test_numeric_grad_3(self):
-
+    def test_numeric_grad_3(self, err, atol):
         def J(x):
             return sum(cos(x))
 
@@ -42,22 +45,19 @@ class TestLogisticRegression(unittest.TestCase):
                        [radians(45)],
                        [radians(60)],
                        [radians(90)]])
-        err = 0.0001
 
         assert_allclose(array([[-sin(radians(30))],
                                [-sin(radians(45))],
                                [-sin(radians(60))],
                                [-sin(radians(90))]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=0.001, equal_nan=False)
+                        rtol=0, atol=atol, equal_nan=False)
 
-    def test_numeric_grad_4(self):
-
+    def test_numeric_grad_4(self, err, atol):
         def J(x):
             return sum(exp(x))
 
         theta = array([[-10], [-1], [0], [1], [10]])
-        err = 0.0001
 
         assert_allclose(array([[exp(-10)],
                                [exp(-1)],
@@ -65,15 +65,13 @@ class TestLogisticRegression(unittest.TestCase):
                                [exp(1)],
                                [exp(10)]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=0.001, equal_nan=False)
+                        rtol=0, atol=atol, equal_nan=False)
 
-    def test_numeric_grad_5(self):
-
+    def test_numeric_grad_5(self, err, atol):
         def J(x):
             return sum(7 * x)
 
         theta = array([[-10], [-1], [0], [1], [10]])
-        err = 0.0001
 
         assert_allclose(array([[7],
                                [7],
@@ -81,10 +79,10 @@ class TestLogisticRegression(unittest.TestCase):
                                [7],
                                [7]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=0.001, equal_nan=False)
+                        rtol=0, atol=atol, equal_nan=False)
 
-    def test_sigmoid_gradient(self):
+    def test_sigmoid_gradient(self, atol):
         z = array([-1, -0.5, 0, 0.5, 1])
         assert_allclose(g_grad(z),
                         [0.196612, 0.235004, 0.25, 0.235004, 0.196612],
-                        rtol=0, atol=0.001, equal_nan=False)
+                        rtol=0, atol=atol, equal_nan=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,11 +13,7 @@ class TestLogisticRegression:
     def err(self):
         return 0.0001
 
-    @pytest.fixture
-    def atol(self):
-        return 0.001
-
-    def test_numeric_grad_1(self, err, atol):
+    def test_numeric_grad_1(self, err):
         def J(x):
             return sum(3 * (x ** 2))
 
@@ -25,9 +21,9 @@ class TestLogisticRegression:
 
         assert_allclose(array([[0], [24], [60]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=atol, equal_nan=False)
+                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_numeric_grad_2(self, err, atol):
+    def test_numeric_grad_2(self, err):
         def J(x):
             return sum(1 / x)
 
@@ -35,9 +31,9 @@ class TestLogisticRegression:
 
         assert_allclose(array([[-0.04], [-0.015625], [-0.0025]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=atol, equal_nan=False)
+                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_numeric_grad_3(self, err, atol):
+    def test_numeric_grad_3(self, err):
         def J(x):
             return sum(cos(x))
 
@@ -51,9 +47,9 @@ class TestLogisticRegression:
                                [-sin(radians(60))],
                                [-sin(radians(90))]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=atol, equal_nan=False)
+                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_numeric_grad_4(self, err, atol):
+    def test_numeric_grad_4(self, err):
         def J(x):
             return sum(exp(x))
 
@@ -65,9 +61,9 @@ class TestLogisticRegression:
                                [exp(1)],
                                [exp(10)]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=atol, equal_nan=False)
+                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_numeric_grad_5(self, err, atol):
+    def test_numeric_grad_5(self, err):
         def J(x):
             return sum(7 * x)
 
@@ -79,10 +75,10 @@ class TestLogisticRegression:
                                [7],
                                [7]]),
                         numerical_grad(J, theta, err),
-                        rtol=0, atol=atol, equal_nan=False)
+                        rtol=0, atol=0.001, equal_nan=False)
 
-    def test_sigmoid_gradient(self, atol):
+    def test_sigmoid_gradient(self):
         z = array([-1, -0.5, 0, 0.5, 1])
         assert_allclose(g_grad(z),
                         [0.196612, 0.235004, 0.25, 0.235004, 0.196612],
-                        rtol=0, atol=atol, equal_nan=False)
+                        rtol=0, atol=0.001, equal_nan=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from math import radians
-import pytest
 
+import pytest
 from numpy import array, cos, sin, exp
 from numpy.testing import assert_allclose
 


### PR DESCRIPTION
Deleted `unitest` occurrences in test code. Basically, the main change was an addition of fixtures in test classes and refactoring of test methods to use these fixtures.

You can run tests now like `pytest tests` from root directory.

This solves #8.