### PR TITLE
Fix #42, replace reStructuredText pydocs for Google Format

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,7 +47,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages'
+    'sphinx.ext.githubpages',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/touvlo/supv/lgx_rg.py
+++ b/touvlo/supv/lgx_rg.py
@@ -14,14 +14,13 @@ from touvlo.utils import g
 def p(x, threshold=0.5):
     """Predicts whether a probability falls into class 1.
 
-    :param x: Probability that example belongs to class 1.
-    :type x: obj
+    Args:
+        x (obj): Probability that example belongs to class 1.
+        threshold (float): point above which a probability is deemed of class
+            1.
 
-    :param threshold: point above which a probability is deemed of class 1.
-    :type threshold: float
-
-    :returns: Binary value to denote class 1 or 0
-    :rtype: int
+    Returns:
+        int: Binary value to denote class 1 or 0
     """
     prediction = None
     if x >= threshold:
@@ -35,16 +34,15 @@ def p(x, threshold=0.5):
 def h(X, theta):
     """Logistic regression hypothesis.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
+    Raises:
+        ValueError
 
-    :raises: ValueError
-
-    :returns: The probability that each entry belong to class 1.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: The probability that each entry belong to class 1.
     """
     return g(X.dot(theta))
 
@@ -52,17 +50,13 @@ def h(X, theta):
 def cost_func(X, y, theta):
     """Computes the cost function J for Logistic Regression.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :returns: Computed cost.
-    :rtype: float
+    Returns:
+        float: Computed cost.
     """
     m = len(y)
     J = (1 / m) * ((-y.T).dot(log(h(X, theta)))
@@ -73,20 +67,14 @@ def cost_func(X, y, theta):
 def reg_cost_func(X, y, theta, _lambda):
     """Computes the regularized cost function J for Logistic Regression.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
+        _lambda (float): The regularization hyperparameter.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :param _lambda: The regularization hyperparameter.
-    :type _lambda: float
-
-    :returns: Computed cost with regularization.
-    :rtype: float
+    Returns:
+        float: Computed cost with regularization.
     """
     m = len(y)
     J = - (1 / m) * ((y.T).dot(log(h(X, theta)))
@@ -98,17 +86,13 @@ def reg_cost_func(X, y, theta, _lambda):
 def grad(X, y, theta):
     """Computes the gradient for the parameters theta.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :returns: Gradient column vector.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Gradient column vector.
     """
     m = len(y)
     grad = (1 / m) * (X.T).dot(h(X, theta) - y)
@@ -118,20 +102,14 @@ def grad(X, y, theta):
 def reg_grad(X, y, theta, _lambda):
     """Computes the regularized gradient for Logistic Regression.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
+        _lambda (float): The regularization hyperparameter.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :param _lambda: The regularization hyperparameter.
-    :type _lambda: float
-
-    :returns: Regularized gradient column vector.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Regularized gradient column vector.
     """
     m = len(y)
     grad = zeros(theta.shape)
@@ -143,32 +121,29 @@ def reg_grad(X, y, theta, _lambda):
 
 
 def predict_prob(X, theta):
-    """ Produces the probability that the entries belong to class 1.
+    """Produces the probability that the entries belong to class 1.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Returns:
+        X (numpy.array): Features' dataset plus bias column.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
+    Raises:
+        ValueError
 
-    :raises: ValueError
-
-    :returns: The probability that each entry belong to class 1.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: The probability that each entry belong to class 1.
     """
     return g(X.dot(theta))
 
 
 def predict(X, theta):
-    """ Classifies each entry as class 1 or class 0.
+    """Classifies each entry as class 1 or class 0.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :returns: Column vector with each entry classification.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Column vector with each entry classification.
     """
     return p(predict_prob(X, theta))

--- a/touvlo/supv/lin_rg.py
+++ b/touvlo/supv/lin_rg.py
@@ -13,14 +13,12 @@ from numpy.linalg import inv, LinAlgError
 def h(X, theta):
     """Linear regression hypothesis.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :returns: The projected value for each line of the dataset.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: The projected value for each line of the dataset.
     """
     return X.dot(theta)
 
@@ -28,17 +26,13 @@ def h(X, theta):
 def cost_func(X, y, theta):
     """Computes the cost function J for Linear Regression.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :returns: Computed cost.
-    :rtype: float
+    Returns:
+        float: Computed cost.
     """
     m = len(y)  # number of training examples
     J = (1 / (2 * m)) * ((h(X, theta) - y).T).dot(h(X, theta) - y)
@@ -48,20 +42,14 @@ def cost_func(X, y, theta):
 def reg_cost_func(X, y, theta, _lambda):
     """Computes the regularized cost function J for Linear Regression.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
+        _lambda (float): The regularization hyperparameter.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :param _lambda: The regularization hyperparameter.
-    :type _lambda: float
-
-    :returns: Computed cost with regularization.
-    :rtype: float
+    Returns:
+        float: Computed cost with regularization.
     """
     m = len(y)  # number of training examples
     J = (1 / (2 * m)) * ((h(X, theta) - y).T).dot(h(X, theta) - y)
@@ -72,17 +60,13 @@ def reg_cost_func(X, y, theta, _lambda):
 def grad(X, y, theta):
     """Computes the gradient for Linear Regression.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :returns: Gradient column vector.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Gradient column vector.
     """
     m = len(y)
     grad = (1 / m) * (X.T).dot(h(X, theta) - y)
@@ -92,20 +76,14 @@ def grad(X, y, theta):
 def reg_grad(X, y, theta, _lambda):
     """Computes the regularized gradient for Linear Regression.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
+        _lambda (float): The regularization hyperparameter.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :param _lambda: The regularization hyperparameter.
-    :type _lambda: float
-
-    :returns: Regularized gradient column vector.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Regularized gradient column vector.
     """
     m = len(y)
     grad = (1 / m) * (X.T).dot(h(X, theta) - y)
@@ -116,14 +94,12 @@ def reg_grad(X, y, theta, _lambda):
 def predict(X, theta):
     """Computes prediction vector.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        theta (numpy.array): Column vector of model's parameters.
 
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :returns: vector with predictions for each input line.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: vector with predictions for each input line.
     """
     return X.dot(theta)
 
@@ -131,16 +107,15 @@ def predict(X, theta):
 def normal_eqn(X, y):
     """Produces optimal theta via normal equation.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
+    Raises:
+        LinAlgError
 
-    :raises: LinAlgError
-
-    :returns: Optimized model parameters theta.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Optimized model parameters theta.
     """
     n = X.shape[1]  # number of columns
     theta = zeros((n + 1, 1), dtype=float64)

--- a/touvlo/supv/nn_clsf.py
+++ b/touvlo/supv/nn_clsf.py
@@ -17,22 +17,15 @@ from touvlo.utils import g, g_grad
 def feed_forward(X, theta, n_hidden_layers=1):
     """Applies forward propagation to calculate model's hypothesis.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        theta (numpy.array): Column vector of model's parameters.
+        n_hidden_layers (int): Number of hidden layers in network.
 
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :param n_hidden_layers: Number of hidden layers in network.
-    :type n_hidden_layers: int
-
-    :returns:
-        - z - array of parameters prior to activation by layer.
-        - a - array of activation matrices by layer.
-
-    :rtype:
-        - z (:py:class: numpy.array(numpy.array))
-        - a (:py:class: numpy.array(numpy.array))
+    Returns:
+        (numpy.array(numpy.array), numpy.array(numpy.array)): A 2-tuple
+            consisting of an array of parameters prior to activation by layer
+            and an array of activation matrices by layer.
     """
     z = empty((n_hidden_layers + 2), dtype=object)
     a = empty((n_hidden_layers + 2), dtype=object)
@@ -57,26 +50,18 @@ def feed_forward(X, theta, n_hidden_layers=1):
 def back_propagation(y, theta, a, z, num_labels, n_hidden_layers=1):
     """Applies back propagation to minimize model's loss.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
+    Args:
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array(numpy.array)): array of model's weight matrices by
+            layer.
+        a (numpy.array(numpy.array)): array of activation matrices by layer.
+        z (numpy.array(numpy.array)): array of parameters prior to sigmoid by
+            layer.
+        num_labels (int): Number of classes in multiclass classification.
+        n_hidden_layers (int): Number of hidden layers in network.
 
-    :param theta: array of model's weight matrices by layer.
-    :type theta: numpy.array(numpy.array)
-
-    :param a: array of activation matrices by layer.
-    :type a: numpy.array(numpy.array)
-
-    :param z: array of parameters prior to sigmoid by layer.
-    :type z: numpy.array(numpy.array)
-
-    :param num_labels: Number of classes in multiclass classification.
-    :type num_labels: int
-
-    :param n_hidden_layers: Number of hidden layers in network.
-    :type n_hidden_layers: int
-
-    :returns: array of matrices of 'error values' by layer.
-    :rtype: numpy.array(numpy.array)
+    Returns:
+        numpy.array(numpy.array): array of matrices of 'error values' by layer.
     """
     delta = empty((n_hidden_layers + 2), dtype=object)
     L = n_hidden_layers + 1  # last layer
@@ -94,17 +79,13 @@ def back_propagation(y, theta, a, z, num_labels, n_hidden_layers=1):
 def h(X, theta, n_hidden_layers=1):
     """Classification Neural Network hypothesis.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        theta (numpy.array): Column vector of model's parameters.
+        n_hidden_layers (int): Number of hidden layers in network.
 
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :param n_hidden_layers: Number of hidden layers in network.
-    :type n_hidden_layers: int
-
-    :returns: The probability that each entry belong to class 1.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: The probability that each entry belong to class 1.
     """
     _, a = feed_forward(X, theta, n_hidden_layers)
     L = n_hidden_layers + 1  # last layer
@@ -116,26 +97,16 @@ def h(X, theta, n_hidden_layers=1):
 def cost_function(X, y, theta, _lambda, num_labels, n_hidden_layers=1):
     """Computes the cost function J for Neural Network.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        y (numpy.array): Column vector of expected values.
+        theta (numpy.array): Column vector of model's parameters.
+        _lambda (float): The regularization hyperparameter.
+        num_labels (int): Number of classes in multiclass classification.
+        n_hidden_layers (int): Number of hidden layers in network.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param theta: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :param _lambda: The regularization hyperparameter.
-    :type _lambda: float
-
-    :param num_labels: Number of classes in multiclass classification.
-    :type num_labels: int
-
-    :param n_hidden_layers: Number of hidden layers in network.
-    :type n_hidden_layers: int
-
-    :returns: Computed cost.
-    :rtype: float
+    Returns:
+        float: Computed cost.
     """
     m, n = X.shape
     intercept = ones((m, 1), dtype=float64)
@@ -162,32 +133,18 @@ def grad(X, y, nn_params, _lambda, input_layer_size,
          hidden_layer_size, num_labels, n_hidden_layers=1):
     """Calculates gradient of neural network's parameters.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        y (numpy.array): Column vector of expected values.
+        nn_params (numpy.array): Column vector of model's parameters.
+        _lambda (float): The regularization hyperparameter.
+        input_layer_size (int): Number of units in the input layer.
+        hidden_layer_size (int): Number of units in a hidden layer.
+        num_labels (int): Number of classes in multiclass classification.
+        n_hidden_layers (int): Number of hidden layers in network.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param nn_params: Column vector of model's parameters.
-    :type theta: numpy.array
-
-    :param _lambda: The regularization hyperparameter.
-    :type _lambda: float
-
-    :param input_layer_size: Number of units in the input layer.
-    :type input_layer_size: int
-
-    :param hidden_layer_size: Number of units in a hidden layer.
-    :type input_layer_size: int
-
-    :param num_labels: Number of classes in multiclass classification.
-    :type num_labels: int
-
-    :param n_hidden_layers: Number of hidden layers in network.
-    :type n_hidden_layers: int
-
-    :returns: array of gradient values by weight matrix.
-    :rtype: numpy.array(numpy.array)
+    Returns:
+        numpy.array(numpy.array): array of gradient values by weight matrix.
     """
     theta = unravel_params(nn_params, input_layer_size, hidden_layer_size,
                            num_labels, n_hidden_layers)
@@ -228,17 +185,13 @@ def grad(X, y, nn_params, _lambda, input_layer_size,
 def rand_init_weights(L_in, L_out):
     """Initializes weight matrix with random values.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        L_in (int): Number of units in previous layer.
+        n_hidden_layers (int): Number of units in next layer.
 
-    :param L_in: Number of units in previous layer.
-    :type L_in: int
-
-    :param n_hidden_layers: Number of units in next layer.
-    :type n_hidden_layers: int
-
-    :returns: Random values' matrix of conforming dimensions.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Random values' matrix of conforming dimensions.
     """
     W = zeros((L_out, 1 + L_in), float64)  # plus 1 for bias term
     epsilon_init = sqrt(6) / sqrt((L_in + 1) + L_out)
@@ -251,23 +204,15 @@ def unravel_params(nn_params, input_layer_size, hidden_layer_size,
                    num_labels, n_hidden_layers=1):
     """Unravels flattened array into list of weight matrices
 
-    :param nn_params: Row vector of model's parameters.
-    :type nn_params: numpy.array
+    Args:
+        nn_params (numpy.array): Row vector of model's parameters.
+        input_layer_size (int): Number of units in the input layer.
+        hidden_layer_size (int): Number of units in a hidden layer.
+        num_labels (int): Number of classes in multiclass classification.
+        n_hidden_layers (int): Number of hidden layers in network.
 
-    :param input_layer_size: Number of units in the input layer.
-    :type input_layer_size: int
-
-    :param hidden_layer_size: Number of units in a hidden layer.
-    :type input_layer_size: int
-
-    :param num_labels: Number of classes in multiclass classification.
-    :type num_labels: int
-
-    :param n_hidden_layers: Number of hidden layers in network.
-    :type n_hidden_layers: int
-
-    :returns: array with model's weight matrices.
-    :rtype: numpy.array(numpy.array)
+    Returns:
+        numpy.array(numpy.array): array with model's weight matrices.
     """
     input_layer_n_units = hidden_layer_size * (input_layer_size + 1)
     hidden_layer_n_units = hidden_layer_size * (hidden_layer_size + 1)
@@ -302,20 +247,14 @@ def init_nn_weights(input_layer_size, hidden_layer_size,
                     num_labels, n_hidden_layers=1):
     """Initialize the weight matrices of a network with random values.
 
-    :param hidden_layer_size: Number of units in a hidden layer.
-    :type input_layer_size: int
+    Args:
+        hidden_layer_size (int): Number of units in a hidden layer.
+        input_layer_size (int): Number of units in the input layer.
+        num_labels (int): Number of classes in multiclass classification.
+        n_hidden_layers (int): Number of hidden layers in network.
 
-    :param input_layer_size: Number of units in the input layer.
-    :type input_layer_size: int
-
-    :param num_labels: Number of classes in multiclass classification.
-    :type num_labels: int
-
-    :param n_hidden_layers: Number of hidden layers in network.
-    :type n_hidden_layers: int
-
-    :returns: array of weight matrices of random values.
-    :rtype: numpy.array(numpy.array)
+    Returns:
+        numpy.array(numpy.array): array of weight matrices of random values.
     """
     theta = empty((n_hidden_layers + 1), dtype=object)
     theta[0] = rand_init_weights(input_layer_size, hidden_layer_size)

--- a/touvlo/unsupv/anmly_detc.py
+++ b/touvlo/unsupv/anmly_detc.py
@@ -16,14 +16,14 @@ from numpy.linalg import det, inv
 def is_anomaly(p, threshold=0.5):
     """Predicts whether a probability falls into class 1 (anomaly).
 
-    :param p: Probability that example belongs to class 1 (is anomaly).
-    :type x: numpy.array
+    Args:
+        p (numpy.array): Probability that example belongs to class 1 (is
+            anomaly).
+        threshold (float): point below which an example is considered of class
+            1.
 
-    :param threshold: point below which an example is considered of class 1.
-    :type threshold: float
-
-    :returns: Binary value to denote class 1 or 0
-    :rtype: int
+    Returns:
+        int: Binary value to denote class 1 or 0
     """
     prediction = array([[1] if el < threshold else [0] for el in p])
     return prediction
@@ -32,14 +32,12 @@ def is_anomaly(p, threshold=0.5):
 def cov_matrix(X, mu):
     """Calculates the covariance matrix for matrix X (m x n).
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        mu (numpy.array): Mean of each feature/column of.
 
-    :param mu: Mean of each feature/column of.
-    :type mu: numpy.array
-
-    :returns: Covariance matrix (n x n)
-    :rtype: int
+    Returns:
+        int: Covariance matrix (n x n)
     """
     m, n = X.shape
     X_minus_mu = X - mu
@@ -51,16 +49,13 @@ def cov_matrix(X, mu):
 def estimate_uni_gaussian(X):
     """Estimates parameters for Univariate Gaussian distribution.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
 
-    :returns:
-        - mu - Mean of each feature/column of X.
-        - sigma2 - Variance of each feature/column of X.
-
-    :rtype:
-        - mu (:py:class: numpy.array)
-        - sigma2 (:py:class: numpy.array)
+    Returns:
+        (numpy.array, numpy.array): A 2-tuple of mu, the mean of each
+            feature/column of X, and sigma2, the variance of each
+            feature/column of X.
     """
     mu = mean(X, axis=0)
     sigma2 = var(X, axis=0)
@@ -70,16 +65,12 @@ def estimate_uni_gaussian(X):
 def estimate_multi_gaussian(X):
     """Estimates parameters for Multivariate Gaussian distribution.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
 
-    :returns:
-        - mu - Mean of each feature/column of X.
-        - sigma - Covariance matrix for X.
-
-    :rtype:
-        - mu (:py:class: numpy.array)
-        - sigma (:py:class: numpy.array)
+    Returns:
+        (numpy.array, numpy.array): A 2-tuple of mu, the mean of each
+            feature/column of X, and sigma, the covariance matrix for X.
     """
     m, n = X.shape
     mu = mean(X, axis=0)
@@ -91,17 +82,13 @@ def estimate_multi_gaussian(X):
 def uni_gaussian(X, mu, sigma2):
     """Estimates probability that examples belong to Univariate Gaussian.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        mu (numpy.array): Mean of each feature/column of X.
+        sigma2 (numpy.array): Variance of each feature/column of X.
 
-    :param mu: Mean of each feature/column of X.
-    :type mu: numpy.array
-
-    :param sigma2: Variance of each feature/column of X.
-    :type sigma2: numpy.array
-
-    :returns: Probability density function for each example
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Probability density function for each example
     """
     p = (1 / sqrt(2 * pi * sigma2))
     p = p * exp(-power(X - mu, 2) / (2 * sigma2))
@@ -116,17 +103,13 @@ def uni_gaussian(X, mu, sigma2):
 def multi_gaussian(X, mu, sigma):
     """Estimates probability that examples belong to Multivariate Gaussian.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        mu (numpy.array): Mean of each feature/column of X.
+        sigma (numpy.array): Covariance matrix for X.
 
-    :param mu: Mean of each feature/column of X.
-    :type mu: numpy.array
-
-    :param sigma: Covariance matrix for X.
-    :type sigma: numpy.array
-
-    :returns: Probability density function for each example
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Probability density function for each example
     """
     m, n = X.shape
     X = X - mu
@@ -144,17 +127,13 @@ def multi_gaussian(X, mu, sigma):
 def predict(X, epsilon, gaussian, **kwargs):
     """Predicts whether examples are anomalies.
 
-    :param X: Features' dataset.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset.
+        epsilon (float): point below which an example is considered of class 1.
+        gaussian (numpy.array): Function that estimates pertinency probability.
 
-    :param epsilon: point below which an example is considered of class 1.
-    :type epsilon: float
-
-    :param gaussian: Function that estimates pertinency probability.
-    :type gaussian: numpy.array
-
-    :returns: Column vector of classification
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Column vector of classification
     """
     p = gaussian(X=X, **kwargs)
     return is_anomaly(p, threshold=epsilon)

--- a/touvlo/unsupv/kmeans.py
+++ b/touvlo/unsupv/kmeans.py
@@ -14,14 +14,12 @@ from numpy.random import permutation
 def euclidean_dist(p, q):
     """Calculates Euclidean distance between 2 n-dimensional points.
 
-    :param p: First n-dimensional point.
-    :type p: numpy.array
+    Args:
+        p (numpy.array): First n-dimensional point.
+        q (numpy.array): Second n-dimensional point.
 
-    :param q: Second n-dimensional point.
-    :type q: numpy.array
-
-    :returns: Distance between 2 points.
-    :rtype: float
+    Returns:
+        float: Distance between 2 points.
     """
     dist = p - q
     dist = power(dist, 2)
@@ -34,14 +32,12 @@ def euclidean_dist(p, q):
 def find_closest_centroids(X, initial_centroids):
     """Assigns to each example the indice of the closest centroid.
 
-    :param X: Features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset
+        initial_centroids (numpy.array): List of initialized centroids.
 
-    :param initial_centroids: List of initialized centroids.
-    :type initial_centroids: list(numpy.array)
-
-    :returns: Column vector of assigned centroids' indices.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Column vector of assigned centroids' indices.
     """
     m = len(X)
     K = len(initial_centroids)
@@ -64,17 +60,13 @@ def find_closest_centroids(X, initial_centroids):
 def compute_centroids(X, idx, K):
     """Computes centroids from the mean of its cluster's members.
 
-    :param X: Features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset
+        idx (numpy.array): Column vector of assigned centroids' indices.
+        K (int): Number of centroids.
 
-    :param idx: Column vector of assigned centroids' indices.
-    :type idx: numpy.array
-
-    :param K: Number of centroids.
-    :type K: int
-
-    :returns: Column vector of newly computed centroids
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Column vector of newly computed centroids
     """
     m, n = X.shape
     centroids = zeros((K, n))
@@ -87,17 +79,13 @@ def compute_centroids(X, idx, K):
 def init_centroids(X, K):
     """Computes centroids from the mean of its cluster's members.
 
-    :param X: Features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset
+        idx (numpy.array): Column vector of assigned centroids' indices.
+        K (int): Number of centroids.
 
-    :param idx: Column vector of assigned centroids' indices.
-    :type idx: numpy.array
-
-    :param K: Number of centroids.
-    :type K: int
-
-    :returns: Column vector of centroids randomly picked from dataset
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Column vector of centroids randomly picked from dataset
     """
     centroids = permutation(X)
     centroids = centroids[0:K, :]
@@ -107,22 +95,14 @@ def init_centroids(X, K):
 def run_kmeans(X, K, max_iters):
     """Applies kmeans using a single random initialization.
 
-    :param X: Features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset
+        K (int): Number of centroids.
+        max_iters (int): Number of times the algorithm will be fitted.
 
-    :param K: Number of centroids.
-    :type K: int
-
-    :param max_iters: Number of times the algorithm will be fitted.
-    :type max_iters: int
-
-    :returns:
-        - centroids -Column vector of centroids
-        - idx -Column vector of assigned centroids' indices.
-
-    :rtype:
-        - centroids (:py:class: numpy.array)
-        - idx (:py:class: numpy.array)
+    Returns:
+        (numpy.array, numpy.array): A 2-tuple of centroids, a column vector of
+            centroids, and idx, a column vector of assigned centroids' indices.
     """
     centroids = init_centroids(X, K)
 
@@ -136,17 +116,12 @@ def run_kmeans(X, K, max_iters):
 def cost_function(X, idx, centroids):
     """Calculates the cost function for K means.
 
-    :param X: Features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset
+        idx (numpy.array): Column vector of assigned centroids' indices.
 
-    :param idx: Column vector of assigned centroids' indices.
-    :type idx: numpy.array
-
-    :returns: Column vector of centroids
-    :rtype: numpy.array
-
-    :returns: Computed cost
-    :rtype: float
+    Returns:
+        float: Computed cost
     """
     cost = 0
     m = len(X)
@@ -161,25 +136,15 @@ def cost_function(X, idx, centroids):
 def run_intensive_kmeans(X, K, max_iters, n_inits):
     """Applies kmeans using multiple random initializations.
 
-    :param X: Features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset
+        K (int): Number of centroids.
+        max_iters (int): Number of times the algorithm will be fitted.
+        n_inits (int): Number of random initialization.
 
-    :param K: Number of centroids.
-    :type K: int
-
-    :param max_iters: Number of times the algorithm will be fitted.
-    :type max_iters: int
-
-    :param n_inits: Number of random initialization.
-    :type n_inits: int
-
-    :returns:
-        - centroids -Column vector of centroids
-        - idx -Column vector of assigned centroids' indices.
-
-    :rtype:
-        - centroids (:py:class: numpy.array)
-        - idx (:py:class: numpy.array)
+    Returns:
+        (numpy.array, numpy.array): A 2-tuple of centroids, a column vector of
+            centroids, and idx, a column vector of assigned centroids' indices.
     """
     min_cost = inf
     best_idx = None
@@ -197,25 +162,15 @@ def run_intensive_kmeans(X, K, max_iters, n_inits):
 def elbow_method(X, K_values, max_iters, n_inits):
     """Calculates the cost for each given K.
 
-    :param X: Features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset
+        K_values (list(int)): List of possible number of centroids.
+        max_iters (int): Number of times the algorithm will be fitted.
+        n_inits (int): Number of random initialization.
 
-    :param K_values: List of possible number of centroids.
-    :type K: list(int)
-
-    :param max_iters: Number of times the algorithm will be fitted.
-    :type max_iters: int
-
-    :param n_inits: Number of random initialization.
-    :type n_inits: int
-
-    :returns:
-        - K_values - List of possible numbers of centroids.
-        - cost_values -Computed cost for each K.
-
-    :rtype:
-        - K_values (:py:class: list(int))
-        - cost_values (:py:class: list(float))
+    Returns:
+        (list(int), list(float)): A 2-tuple of K_values, a list of possible
+            numbers of centroids, and cost_values, a computed cost for each K.
     """
     cost_values = []
     for K in K_values:

--- a/touvlo/unsupv/pca.py
+++ b/touvlo/unsupv/pca.py
@@ -12,16 +12,12 @@ from numpy import diag
 def pca(X):
     """Runs Principal Component Analysis on dataset
 
-    :param X: Features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset
 
-    :returns:
-        - U - eigenvectors of covariance matrix
-        - S - eigenvalues (on diagonal) of covariance matrix
-
-    :rtype:
-        - U (:py:class: numpy.array)
-        - S (:py:class: numpy.array)
+    Returns:
+        (numpy.array, numpy.array): A 2-tuple of U, eigenvectors of covariance
+            matrix, and S, eigenvalues (on diagonal) of covariance matrix.
     """
     m, n = X.shape
     Sigma = (1 / m) * X.T.dot(X)
@@ -34,16 +30,13 @@ def pca(X):
 def project_data(X, U, k):
     """Computes reduced data representation (projected data)
 
-    :param X: Normalized features' dataset
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Normalized features' dataset
+        U (numpy.array): eigenvectors of covariance matrix
+        k (int): Number of features in reduced data representation
 
-    :param U: eigenvectors of covariance matrix
-    :type U: numpy.array
-
-    :param k: Number of features in reduced data representation
-
-    :returns: Reduced data representation (projection)
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Reduced data representation (projection)
     """
     U_reduce = U[:, 0:k]
     Z = X.dot(U_reduce)
@@ -53,16 +46,13 @@ def project_data(X, U, k):
 def recover_data(Z, U, k):
     """Recovers an approximation of original data using the projected data
 
-    :param Z: Reduced data representation (projection)
-    :type Z: numpy.array
+    Args:
+        Z (numpy.array): Reduced data representation (projection)
+        U (numpy.array): eigenvectors of covariance matrix
+        k (int): Number of features in reduced data representation
 
-    :param U: eigenvectors of covariance matrix
-    :type U: numpy.array
-
-    :param k: Number of features in reduced data representation
-
-    :returns: Approximated features' dataset
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Approximated features' dataset
     """
     X_rec = Z.dot(U[:, 0:k].T)
     return X_rec

--- a/touvlo/utils.py
+++ b/touvlo/utils.py
@@ -12,11 +12,11 @@ from numpy import zeros, copy, std, mean, float64, exp, seterr
 def g(x):
     """This function applies the sigmoid function on a given value.
 
-    :param x: Input value or object containing value .
-    :type x: obj
+    Args:
+        x (obj): Input value or object containing value .
 
-    :returns: Sigmoid function at value.
-    :rtype: obj
+    Returns:
+        obj: Sigmoid function at value.
     """
     return 1 / (1 + exp(-x))
 
@@ -25,11 +25,11 @@ def g(x):
 def g_grad(x):
     """This function calculates the sigmoid gradient at a given value.
 
-    :param x: Input value or object containing value .
-    :type x: obj
+    Args:
+        x (obj): Input value or object containing value .
 
-    :returns: Sigmoid gradient at value.
-    :rtype: obj
+    Returns:
+        obj: Sigmoid gradient at value.
     """
     return g(x) * (1 - g(x))
 
@@ -38,26 +38,18 @@ def BGD(X, y, grad, initial_theta,
         alpha, num_iters, **kwargs):
     """Performs parameter optimization via Batch Gradient Descent.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        grad (numpy.array): Routine that generates the partial derivatives
+            given theta.
+        initial_theta (numpy.array): Initial value for parameters to be
+            optimized.
+        alpha (float): Learning rate or _step size of the optimization.
+        num_iters (int): Number of times the optimization will be performed.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param grad: Routine that generates the partial derivatives given theta.
-    :type grad: numpy.array
-
-    :param initial_theta: Initial value for parameters to be optimized.
-    :type initial_theta: numpy.array
-
-    :param alpha: Learning rate or _step size of the optimization.
-    :type alpha: float
-
-    :param num_iters: Number of times the optimization will be performed.
-    :type num_iters: int
-
-    :returns: Optimized model parameters.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Optimized model parameters.
     """
     theta = copy(initial_theta)
     for _ in range(num_iters):
@@ -70,26 +62,18 @@ def SGD(X, y, grad, initial_theta,
         alpha, num_iters, **kwargs):
     """Performs parameter optimization via Stochastic Gradient Descent.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        grad (numpy.array): Routine that generates the partial derivatives
+            given theta.
+        initial_theta (numpy.array): Initial value for parameters to be
+            optimized.
+        alpha (float): Learning rate or _step size of the optimization.
+        num_iters (int): Number of times the optimization will be performed.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param grad: Routine that generates the partial derivatives given theta.
-    :type grad: numpy.array
-
-    :param initial_theta: Initial value for parameters to be optimized.
-    :type initial_theta: numpy.array
-
-    :param alpha: Learning rate or _step size of the optimization.
-    :type alpha: float
-
-    :param num_iters: Number of times the optimization will be performed.
-    :type num_iters: int
-
-    :returns: Optimized model parameters.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Optimized model parameters.
     """
     m = len(y)
     theta = copy(initial_theta)
@@ -105,29 +89,19 @@ def MBGD(X, y, grad, initial_theta,
          alpha, num_iters, b, **kwargs):
     """Performs parameter optimization via Mini-Batch Gradient Descent.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
+        y (numpy.array): Column vector of expected values.
+        grad (numpy.array): Routine that generates the partial derivatives
+            given theta.
+        initial_theta (numpy.array): Initial value for parameters to be
+            optimized.
+        alpha (float): Learning rate or _step size of the optimization.
+        num_iters (int): Number of times the optimization will be performed.
+        b (int): Number of examples in mini batch.
 
-    :param y: Column vector of expected values.
-    :type y: numpy.array
-
-    :param grad: Routine that generates the partial derivatives given theta.
-    :type grad: numpy.array
-
-    :param initial_theta: Initial value for parameters to be optimized.
-    :type initial_theta: numpy.array
-
-    :param alpha: Learning rate or _step size of the optimization.
-    :type alpha: float
-
-    :param num_iters: Number of times the optimization will be performed.
-    :type num_iters: int
-
-    :param b: Number of examples in mini batch.
-    :type b: int
-
-    :returns: Optimized model parameters.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Optimized model parameters.
     """
     m = len(y)
     theta = copy(initial_theta)
@@ -149,17 +123,13 @@ def MBGD(X, y, grad, initial_theta,
 def numerical_grad(J, theta, err):
     """Numerically calculates the gradient of a given cost function.
 
-    :param J: Function handle that computes cost given theta.
-    :type J: function
+    Args:
+        J (Callable): Function handle that computes cost given theta.
+        theta (numpy.array): Model parameters.
+        err (float): distance between points where J is evaluated.
 
-    :param theta: Model parameters.
-    :type theta: numpy.array
-
-    :param err: distance between points where J is evaluated.
-    :type err: float
-
-    :returns: Computed numeric gradient.
-    :rtype: numpy.array
+    Returns:
+        numpy.array: Computed numeric gradient.
     """
     num_grad = zeros(theta.shape, dtype=float64)
     perturb = zeros(theta.shape, dtype=float64)
@@ -177,18 +147,13 @@ def numerical_grad(J, theta, err):
 def feature_normalize(X):
     """Performs Z score normalization in a numeric dataset.
 
-    :param X: Features' dataset plus bias column.
-    :type X: numpy.array
+    Args:
+        X (numpy.array): Features' dataset plus bias column.
 
-    :returns:
-        - X_norm - Normalized features' dataset.
-        - mu - Mean of each feature
-        - sigma - Standard deviation of each feature.
-
-    :rtype:
-        - X_norm (:py:class: numpy.array)
-        - mu (:py:class: numpy.array)
-        - sigma (:py:class: numpy.array)
+    Returns:
+        (numpy.array, numpy.array, numpy.array): A 3-tuple of X_norm,
+            normalized features' dataset, mu, mean of each feature, and sigma,
+            standard deviation of each feature.
     """
     seterr(divide='ignore', invalid='ignore')
     mu = mean(X, axis=0)


### PR DESCRIPTION
## Replace reStructuredText pydocs for Google Format

This PR fixes #42 by replacing reStructuredText style docstrings with Google style docstrings. It adds `sphinx.ext.napoleon` in `docs/source/conf.py` to permit correct rendering. No other changes should be required.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I installed Sphinx locally and ran it to see that documentation was generated appropriately.

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/Benardi/touvlo/blob/master/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes